### PR TITLE
Phone parser undefined variable reference

### DIFF
--- a/lib/valerie/phone.rb
+++ b/lib/valerie/phone.rb
@@ -3,53 +3,53 @@ require_relative 'ordered'
 module Valerie
   class Phone
     VALID_TYPES = %w[text voice fax cell video pager textphone].freeze
-    
+
     include Ordered
-    
+
     def self.from_s(data)
       data = data[data.index("TEL;")..] unless data.start_with?("TEL;")
       identifier = data.split(":").last
       options = data.gsub("TEL", "").split(":").first.split(";").compact.filter { _1.to_s.include?('=')}.map { _1.downcase.split("=") }.to_h
-      
+
       new(identifier, **options)
     end
-    
+
     attr_reader :number, :options
-    
+
     def initialize(number, **options)
       @number = number
       @options = options.transform_keys!(&:to_sym)
       @type = @options[:type] || 'voice'
-      
+
       raise ArgumentError, 'Invalid Position' if invalid_position?
     end
-    
+
     def [](key)
       @options[key]
     end
-    
+
     def to_s
       parts = ['TEL']
-      
+
       parts << "PERF=#{@options[:position]}" if position?
       parts << type_to_s if type?
-      
+
       parts.join(';') + ":#{@number}"
     end
-    
+
     def to_h
       {
-        number: @tel,
+        number: @number,
         type: @type,
         position: @options[:position],
       }
     end
-    
+
     private
       def type?
         @options[:type]
       end
-      
+
       def type_to_s
         if @options[:type].is_a?(Array)
           "TYPE=\"#{@options[:type].join(',')}\""

--- a/test/phone_test.rb
+++ b/test/phone_test.rb
@@ -6,24 +6,30 @@ class PhoneTest < Minitest::Test
       assert_equal(phone.to_s.start_with?('TEL;TYPE=voice:'), true)
     end
   end
-  
+
   def test_to_s_with_multiple_types
     Valerie::Phone.new('01000000000', type: %i[voice work]).tap do |phone|
       assert_equal(phone.to_s, 'TEL;TYPE="voice,work":01000000000')
     end
   end
-  
+
   def test_with_invalid_position
     error = assert_raises(ArgumentError) do
       Valerie::Phone.new('01000000000', position: -1)
     end
-    
+
     assert_equal(error.message, 'Invalid Position')
   end
-  
+
   def test_to_s_with_position
     Valerie::Phone.new('01000000000', type: :voice, position: 1).tap do |phone|
       assert_equal(phone.to_s, 'TEL;PERF=1;TYPE=voice:01000000000')
+    end
+  end
+
+  def test_to_h
+    Valerie::Phone.new('01000000000', type: :voice, position: 1).tap do |phone|
+      assert_equal(phone.to_h, { number: '01000000000', type: :voice, position: 1 })
     end
   end
 end

--- a/valerie.gemspec
+++ b/valerie.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'valerie'
-  s.version = '0.0.7'
+  s.version = '0.0.8'
   s.summary = 'Easily parse and generate VCard (Contact Card) objects that can be exported to other systems with ease.'
   s.description = 'VCard (Contact Card) parser and generator.'
   s.authors = ['Hellotext', 'Ahmed Khattab']
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.required_ruby_version = '>= 3.3.0'
-  
+
   s.add_development_dependency 'minitest', '~> 5.14'
   s.add_development_dependency 'rake', '~> 13.0'
 end


### PR DESCRIPTION
This PR fixes a bug with the phone parser where it was referencing the wrong `@tel` variable instead of the `@number` instance variable. 